### PR TITLE
nan version update for NodeJs 10.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.4.0"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "mocha": "^3.1.0",


### PR DESCRIPTION
Hi, 
Please update the nan version to 2.10.0 for supporting NodeJs 10.x.
Maybe new branch is required since the nodejs backward compatibility is not checked thoroughly.
Br,
Ari